### PR TITLE
Fix docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,22 @@
-FROM node:12.16.1-alpine
+FROM node:12
 
-RUN mkdir -p /home/node/app/node_modules && mkdir -p /home/node/app/logs && chown -R node:node /home/node/app 
-RUN apk update && apk add yarn python g++ make && rm -rf /var/cache/apk/*
+# Create app directory
+WORKDIR /usr/src/app
 
-WORKDIR /home/node/app
-
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
 COPY package*.json ./
-
-USER node
+COPY yarn.lock ./
 
 RUN yarn install 
 
-COPY --chown=node:node . .
+# Bundle app source
+COPY . .
+
+ENV PORT=9003
 
 EXPOSE 9003
 
+# Stage 2 - Run the application
 CMD [ "yarn", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 version: '3.7'
 
 services:
-    nodejs:
+    butler:
         build:
             context: .
             dockerfile: Dockerfile
-        image: butler
+        depends_on:
+            - mongo-db
         container_name: butler
         restart: unless-stopped
         env_file: .env
@@ -14,13 +15,12 @@ services:
         ports:
             - '9003:9003'
         volumes:
-            - .:/home/node/app
-            - node_modules:/home/node/app/node_modules
-            - logs:/home/node/app/logs
-        networks:
-            - app-network
-        command: ./wait-for.sh db:27017 -- yarn start
-    db:
+            - .:/app/
+            - /app/node_modules
+            - ./logs:/home/node/app/logs
+        command: yarn start
+    
+    mongo-db:
         image: 'bitnami/mongodb:latest'
         container_name: db
         restart: unless-stopped
@@ -29,18 +29,6 @@ services:
             - MONGO_INITDB_ROOT_PASSWORD=$MONGO_PASSWORD
         volumes:
             - dbdata:/data/db
-        networks:
-            - app-network
 
-networks:
-    app-network:
-        driver: bridge
 volumes:
     dbdata:
-    node_modules:
-    logs:
-        driver: local
-        driver_opts:
-            type: none
-            device: $PWD/logs
-            o: bind


### PR DESCRIPTION
This PR fixes the docker setup.

Dockerfile:
- [x] do not create and require a new user in the container
- [x] use `node:12` docker image as base (it comes with `yarn` pre-installed)
- [x] dump yarn global install
- [x] correct copy
- [x] set env port

docker-compose:
- [x] simplify shared volumes
- [x] make the `butler` container dependant on the mongodb
- [x] shared network custom config not required (because the networks are depending on each other) 